### PR TITLE
Add support for new configuration options.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.1.1
 commit = True
 tag = True
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: python
 python:
-    - "3.3"
     - "3.4"
     - "3.5"
+    - "3.6"
+    - "3.7"
+    - "3.8"
     - "nightly"
 install:
     - pip install .
-script: 
+script:
     - py.test

--- a/README.rst
+++ b/README.rst
@@ -1,23 +1,24 @@
-*******************************
+**********
 Spare Keys
-*******************************
-Spare Keys makes and distributes encrypted copies of the files that you would 
-need to recover from a catastrophic hard drive failure, e.g. SSH keys, GPG 
+**********
+
+Spare Keys makes and distributes encrypted copies of the files that you would
+need to recover from a catastrophic hard drive failure, e.g. SSH keys, GPG
 keys, password vaults, etc.  The basic process goes like this:
 
-- You specify which files you want to keep spare copies of.  You can do this by 
+- You specify which files you want to keep spare copies of.  You can do this by
   editing a configuration file, or by installing plugins.
 
-- You specify where you want to store encrypted copies of theses files (e.g.  
+- You specify where you want to store encrypted copies of theses files (e.g.
   remote hosts, USB drives, etc.), again via configuration files or plugins.
 
-- Run ``sparekeys`` to automatically create, encrypt, and distribute spare 
-  copies of the specified files to the specified locations.  A decryption 
-  script is distributed with the archive, so the only thing you need to 
+- Run ``sparekeys`` to automatically create, encrypt, and distribute spare
+  copies of the specified files to the specified locations.  A decryption
+  script is distributed with the archive, so the only thing you need to
   remember is the password you used for the encryption.
 
-- If you ever lose your hard drive, download the most recent archive from any 
-  of the backup locations and run the provided decryption script to recover 
+- If you ever lose your hard drive, download the most recent archive from any
+  of the backup locations and run the provided decryption script to recover
   your credentials.
 
 .. image:: https://img.shields.io/pypi/v/sparekeys.svg
@@ -40,24 +41,28 @@ Spare Keys can be installed from PyPI::
 
 Note that Spare Keys requires python≥3.6.
 
+
 Usage
 =====
+
 To get started, simply run the following command::
 
    $ sparekeys
 
-This will create and execute a default configuration that will save your SSH 
-and GPG credentials.  Your credentials won't be copied anywhere, but the path 
+This will create and execute a default configuration that will save your SSH
+and GPG credentials.  Your credentials won't be copied anywhere, but the path
 to the encrypted archive will be shown so that you can copy it yourself.
 
 For more information::
 
    $ sparekeys -h
 
+
 Examples
 ========
-Below are some example Spare Keys configuration files to help get you started.  
-See the Configuration_ and Plugins_ sections for more information on these 
+
+Below are some example Spare Keys configuration files to help get you started.
+See the Configuration_ and Plugins_ sections for more information on these
 options.
 
 Copy SSH and GPG keys to a remote host via ``scp``::
@@ -70,7 +75,7 @@ Copy SSH and GPG keys to a remote host via ``scp``::
    host = 'alice@example.com'
 
 Copy SSH and GPG keys to a USB drive mounted at ``/mnt/usb``::
-   
+
    [plugins]
    archive = ['ssh', 'gpg']
    publish = ['mount']
@@ -88,7 +93,7 @@ Archive SSH keys, GPG keys, and a cryptocurrency wallet:
    [archive.file]
    src = '~/.config/cryptocurrency'
 
-Use your avendesora__ "login" credentials to encrypt the archive.  As a 
+Use your avendesora__ "login" credentials to encrypt the archive.  As a
 fallback, prompt for a password (getpass)::
 
    [plugins]
@@ -100,14 +105,16 @@ fallback, prompt for a password (getpass)::
 
 __ https://github.com/kenkundert/avendesora
 
+
 Configuration
 =============
-The configuration file is based on the `TOML file format 
+
+The configuration file is based on the `TOML file format
 <https://github.com/toml-lang/toml>`_.  On Linux systems, it can be found at::
 
    ~/.config/sparekeys/config.toml
 
-Broadly, you need to enable any plugins use with to use, and you need to 
+Broadly, you need to enable any plugins use with to use, and you need to
 configure any plugins that require extra information::
 
    ## Enable plugins ###############################################
@@ -131,45 +138,46 @@ configure any plugins that require extra information::
    [publish.scp]
    drive = '/mnt/usb'
 
-You can get a list of installed plugins by running ``sparekeys plugins``.  More 
-information on the built-in plugins is available in the `Plugins`_ section 
+You can get a list of installed plugins by running ``sparekeys plugins``.  More
+information on the built-in plugins is available in the `Plugins`_ section
 below.  The `Plugin API`_ section described how you can make your own plugins.
 
 The ``[plugins]`` block:
-   
-- ``archive`` (list): A list of plugins to use for finding important files and 
+
+- ``archive`` (list): A list of plugins to use for finding important files and
   building the archive.  Built-in options include 'ssh', 'gpg', and 'file'.
 
-- ``publish`` (list): A list of plugins to use when copying the encrypted 
+- ``publish`` (list): A list of plugins to use when copying the encrypted
   archive to remote destinations.  Built-in options include 'scp' and 'mount'
 
-- ``auth`` (list): A list of plugins to query for a password when encrypting 
-  archive.  The plugins will be invoked in the order specified until a passcode 
-  is obtained.  Any subsequent plugins will not be invoked.  If no 
-  authentication plugins are specified, the built-in 'getpass' plugin (which 
-  asks for a passcode in the terminal) will be used.  If no passcode can be 
+- ``auth`` (list): A list of plugins to query for a password when encrypting
+  archive.  The plugins will be invoked in the order specified until a passcode
+  is obtained.  Any subsequent plugins will not be invoked.  If no
+  authentication plugins are specified, the built-in 'getpass' plugin (which
+  asks for a passcode in the terminal) will be used.  If no passcode can be
   obtained, the archive will not be created.
 
-The configuration blocks:
 
-The remaining blocks provide configuration options specific to individual 
-plugins.  The block follow the naming pattern: ``[STAGE.PLUGIN]``.  ``STAGE`` 
-is the category of plugin, e.g. one of ``archive``, ``publish``, or ``auth``.  
-``PLUGIN`` is the name of the plugin, which could be anything.  Within the 
-block go any options relating to the plugin in question.  Each plugin 
+**The configuration blocks:**
+
+The remaining blocks provide configuration options specific to individual
+plugins.  The block follow the naming pattern: ``[STAGE.PLUGIN]``.  ``STAGE``
+is the category of plugin, e.g. one of ``archive``, ``publish``, or ``auth``.
+``PLUGIN`` is the name of the plugin, which could be anything.  Within the
+block go any options relating to the plugin in question.  Each plugin
 understands a different set of options.
 
-Below is an example configuration block for the ``publish.scp`` plugin, which 
+Below is an example configuration block for the ``publish.scp`` plugin, which
 describes how to copy the archive to a remote host via scp::
 
    [publish.scp]
    host = ['alice@home.net', 'alice@work.com']
    remote_dir = 'backup'
 
-It is also possible to specify multiple configuration blocks for any individual 
-plugin (except the authentication plugins).  If you do this, the plugin will be 
-executed once for each such block.  For example, the following configuration 
-would publish the spare keys to two different directories on two different 
+It is also possible to specify multiple configuration blocks for any individual
+plugin (except the authentication plugins).  If you do this, the plugin will be
+executed once for each such block.  For example, the following configuration
+would publish the spare keys to two different directories on two different
 remote hosts::
 
    [[publish.scp]]
@@ -180,21 +188,22 @@ remote hosts::
    host = 'alice@work.com'
    remote_dir = '/backups/alice/'
 
-Top-level options:
 
-- ``archive_name`` (str, default: ``'{host}'``): A format string that will be 
-  used to name each archive.  The following values can be substituted using the 
+**Top-level options:**
+
+- ``archive_name`` (str, default: ``'{host}'``): A format string that will be
+  used to name each archive.  The following values can be substituted using the
   standrad python formatting syntax:
-  
+
    - ``{user}``: The name of the logged-in user.
    - ``{host}``: The name of the current machine.
-   - ``{date:YYYYMMDD}``: The current date.  The characters after the colon 
-     specify how the date should be `formatted 
-     <https://arrow.readthedocs.io/en/latest/#format>`.  
+   - ``{date:YYYYMMDD}``: The current date.  The characters after the colon
+     specify how the date should be `formatted
+     <https://arrow.readthedocs.io/en/latest/#format>`.
 
 Plugins
 =======
-Spare Keys supports the use of setuptools plugins to customize the backup 
+Spare Keys supports the use of setuptools plugins to customize the backup
 process.  Below are descriptions of all the built-in plugins:
 
 ``archive.ssh``
@@ -204,75 +213,78 @@ process.  Below are descriptions of all the built-in plugins:
    Copy the ``.gpg`` directory into the archive.  No configuration options.
 
 ``archive.file``
-   Copy arbitrary files into the archive.  This plugin is provided to make it 
-   easy to copy valuable files for which devoted plugins are not available.  
+   Copy arbitrary files into the archive.  This plugin is provided to make it
+   easy to copy valuable files for which devoted plugins are not available.
    The following option must be configured:
 
-   - ``src`` (str or list): One or more paths to copy.  The copied file(s) will 
-     have the same path relative to the archive as the original file(s) have 
+   - ``src`` (str or list): One or more paths to copy.  The copied file(s) will
+     have the same path relative to the archive as the original file(s) have
      relative to the home directory.
 
 ``archive.emborg``
-   Copy files for `borg backup <https://www.borgbackup.org/>` and its `emborg 
-   front-end <https://github.com/KenKundert/emborg>` into the archive.  These 
-   files include the keys and configuration options necessary to recover your 
-   backups.  The `borg key export` command is run to download keys for 
+   Copy files for `borg backup <https://www.borgbackup.org/>` and its `emborg
+   front-end <https://github.com/KenKundert/emborg>` into the archive.  These
+   files include the keys and configuration options necessary to recover your
+   backups.  The `borg key export` command is run to download keys for
    'repokey' backups, protecting against corruption in the backup archive.
-   
-   No configuration options.
+
+   - ``config`` (str): Name of emborg configuration to use. If not given the 
+     default configuration is used.
 
 ``archive.avendesora``
-   Copy configuration files for the `avendesora 
-   <https://github.com/kenkundert/avendesora>` password manager into the 
+   Copy configuration files for the `avendesora
+   <https://github.com/kenkundert/avendesora>` password manager into the
    archive.
-   
+
    No configuration options.
 
 ``publish.scp``
-   Copy the encrypted archive to a remote host via ``scp``.  The following 
+   Copy the encrypted archive to a remote host via ``scp``.  The following
    configuration options are available:
 
-   - ``host`` (str or list, required): The name(s) of the remote host(s) to 
+   - ``host`` (str or list, required): The name(s) of the remote host(s) to
      copy the archive to.  Any format understood by SSH is acceptable.
 
-   - ``remote_dir`` (str, default: ``'backup/sparekeys'``): The directory where 
+   - ``remote_dir`` (str, default: ``'backup/sparekeys'``): The directory where
      the spare keys should be stored on the remote host.
 
 ``publish.mount``
    Copy the encrypted archive to a mounted/mountable drive.
-   For example, it might be a good idea to copy your keys onto a USB drive 
-   which could be stored in a safe-deposit box.  The following configuration 
+   For example, it might be a good idea to copy your keys onto a USB drive
+   which could be stored in a safe-deposit box.  The following configuration
    options are available:
 
-   - ``drive`` (str): The path to the mountpoint for the drive, which must be 
-     present and configured in ``/etc/fstab``.  If the drive is not mounted 
-     when Spare Keys runs, Spare Keys will attempt to mount it and will (if 
-     successful) unmount it when finished.  If the drive is mounted when Spare 
+   - ``drive`` (str): The path to the mountpoint for the drive, which must be
+     present and configured in ``/etc/fstab``.  If the drive is not mounted
+     when Spare Keys runs, Spare Keys will attempt to mount it and will (if
+     successful) unmount it when finished.  If the drive is mounted when Spare
      Keys runs, Spare Keys will leave it mounted.
 
-   - ``remote_dir`` (str, default: ``'backup/sparekeys'``): The directory where 
+   - ``remote_dir`` (str, default: ``'backup/sparekeys'``): The directory where
      the spare keys should be stored on the mounted drive.
 
 ``auth.getpass``
-   Get a passcode for the archive by prompting for one in the terminal.  The 
-   passcode is never printed to the terminal and never saved anywhere.  This 
-   plugin is special in that it is the default if no other authentication 
+   Get a passcode for the archive by prompting for one in the terminal.  The
+   passcode is never printed to the terminal and never saved anywhere.  This
+   plugin is special in that it is the default if no other authentication
    plugins are enabled.
 
 ``auth.avendesora``
-   Get a passcode for the archive from avendesora__.  The following 
-   configuration option is required:
-
+   Get a passcode for the archive from avendesora__.
    __ https://github.com/kenkundert/avendesora
 
-   - ``account`` (str): The name of the account to get the passcode for.  It's 
-     recommended to use a password you have completely memorized (e.g. a login 
-     password), because avendesora itself is unlikely to be available to you if 
-     you ever need to recover your keys.
+   - ``account`` (str): The name of the account to get the passcode for.  It's
+     recommended to use a password you have completely memorized (e.g. a login
+     password), because avendesora itself is unlikely to be available to you if
+     you ever need to recover your keys.  This configuration option is required.
+   - ``field`` (str): The name of the account field that contains the password 
+     or pass phrase. If not given, avendesora chooses a likely candidate for 
+     you.
+
 
 Plugin API
 ==========
-Plugins can be installed using the `setuptools Entry Points API 
+Plugins can be installed using the `setuptools Entry Points API
 <https://amir.rachum.com/blog/2017/07/28/python-entry-points/>`::
 
    setup(
@@ -291,22 +303,22 @@ Plugins can be installed using the `setuptools Entry Points API
       ...
    )
 
-Currently, three entry points are supported: ``sparekeys.archive``, 
-``sparekeys.publish``, and ``sparekeys.auth``.  These entry points correspond 
-to the three categories of plugins detailed in the Configuration_ section 
-above.  Each plugin must have a unique name within its category ("spam" in the 
+Currently, three entry points are supported: ``sparekeys.archive``,
+``sparekeys.publish``, and ``sparekeys.auth``.  These entry points correspond
+to the three categories of plugins detailed in the Configuration_ section
+above.  Each plugin must have a unique name within its category ("spam" in the
 example above).
 
 An ``archive`` plugin must be a function that accepts two arguments:
 
 - A dictionary with any configuration values specific to the plugin.
 - The path to the archive.
-  
-The function must copy any necessary files into the archive, possibly after 
-doing more complicated things like generating or downloading said files.  The 
-``sparekeys.copy_to_archive()`` utility is often useful for these plugins.  It 
-copies files into the archive such that their path within the archive is the 
-same as their path relative to the home directory.  Below is an example that 
+
+The function must copy any necessary files into the archive, possibly after
+doing more complicated things like generating or downloading said files.  The
+``sparekeys.copy_to_archive()`` utility is often useful for these plugins.  It
+copies files into the archive such that their path within the archive is the
+same as their path relative to the home directory.  Below is an example that
 copies ``~/.config/spam`` into the archive::
 
    def archive_spam(config, archive):
@@ -315,10 +327,10 @@ copies ``~/.config/spam`` into the archive::
 A ``publish`` plugin must be a function that accepts two arguments:
 
 - A dictionary with any configuration values specific to the plugin.
-- The path the directory containing the encrypted archive (called 
+- The path the directory containing the encrypted archive (called
   ``archive.tgz.gpg``) and the decryption script (called ``decrypt.sh``).
 
-The plugin should copy the encrypted archive to a remote destination.  Below is 
+The plugin should copy the encrypted archive to a remote destination.  Below is
 an example that simply copies the archive to ``~/spam``::
 
    def publish_spam(config, workspace):
@@ -328,25 +340,26 @@ An ``auth`` plugin must be a function that accepts one argument:
 
 - A dictionary with any configuration values specific to the plugin.
 
-The plugin should either return a passcode or raise one of the exceptions 
-detailed below.  A typical plugin might query a particular password valut, 
-using an account specified in the given configuration.  Below is an example 
+The plugin should either return a passcode or raise one of the exceptions
+detailed below.  A typical plugin might query a particular password valut,
+using an account specified in the given configuration.  Below is an example
 that simply returns the string "spam"::
 
    def auth_spam(config):
        return "spam"
 
-Exceptions:
+
+**Exceptions:**
 
 Plugins can raise the following exceptions:
 
-- ``SkipPlugin``: The plugin can't do its job for some reason.  A warning will 
+- ``SkipPlugin``: The plugin can't do its job for some reason.  A warning will
   be printed, but the program will continue.
 
-- ``PluginConfigError``: Something about the plugin's configuration doesn't 
-  make sense and/or is missing.  The program will be stopped and an informative 
+- ``PluginConfigError``: Something about the plugin's configuration doesn't
+  make sense and/or is missing.  The program will be stopped and an informative
   error will be displayed.
 
-- ``PluginError``: Something else went wrong.  The program will be aborted 
+- ``PluginError``: Something else went wrong.  The program will be aborted
   immediately and an informative error will be displayed..
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
    contain the root `toctree` directive.
 
 Welcome to Spare Keys's documentation!
-===========================================================
+======================================
 
 Contents:
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.rst') as file:
 
 setup(
     name='sparekeys',
-    version='0.1.0',
+    version='0.1.1',
     author='Kale Kundert',
     author_email='kale@thekunderts.net',
     long_description=readme,

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
             'gpg=sparekeys:archive_gpg',
             'file=sparekeys:archive_file',
             'emborg=sparekeys:archive_emborg',
+                # wants emborg=>1.1, but that version is not available yet.
             'avendesora=sparekeys:archive_avendesora',
         ],
         'sparekeys.publish': [

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
             'gpg=sparekeys:archive_gpg',
             'file=sparekeys:archive_file',
             'emborg=sparekeys:archive_emborg',
-                # wants emborg=>1.1, but that version is not available yet.
+                # needs emborg version 1.2 or greater
             'avendesora=sparekeys:archive_avendesora',
         ],
         'sparekeys.publish': [
@@ -42,8 +42,8 @@ setup(
         ],
     },
     install_requires=[
-        'inform',
-        'shlib',
+        'inform>-1.14',
+        'shlib>=1.0',
         'setuptools',
         'toml',
         'appdirs',

--- a/sk
+++ b/sk
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+
+from sparekeys.main import main
+main()

--- a/sparekeys/main.py
+++ b/sparekeys/main.py
@@ -34,8 +34,14 @@ import pkg_resources
 
 from collections import namedtuple
 from pkg_resources import iter_entry_points
-from inform import Inform as set_output_prefs, Error, display, output, narrate, warn, error, plural, get_informer, terminate
-from shlib import cd, chmod, cp, ls, mkdir, mount, rm, Run as run, to_path, set_prefs as set_shlib_prefs
+from inform import (
+    Inform as set_output_prefs, Error, display, output, narrate, warn, error,
+    fatal, plural, get_informer, terminate, os_error
+)
+from shlib import (
+    cd, chmod, cp, ls, mkdir, mount, rm, Run as run, to_path, set_prefs as
+    set_shlib_prefs
+)
 from textwrap import shorten
 from functools import lru_cache
 from shutil import get_terminal_size
@@ -75,15 +81,17 @@ def main():
             encrypt_archive(config, archive, passcode)
             publish_archive(config, archive)
 
-        except ConfigError as err:
-            err.reraise(culprit=config_path)
+        except ConfigError as e:
+            e.reraise(culprit=config_path)
 
     except KeyboardInterrupt:
         print()
 
-    except Error as err:
+    except Error as e:
         if args['--verbose']: raise
-        else: err.report()
+        else: e.report()
+    except OSError as e:
+        fatal(os_error(e))
     terminate()
 
 
@@ -101,8 +109,8 @@ def load_config():
 
     try:
         config = toml.load(config_path)
-    except toml.decoder.TomlDecodeError as err:
-        raise ConfigError(str(err), culprit=config_path)
+    except toml.decoder.TomlDecodeError as e:
+        raise ConfigError(str(e), culprit=config_path)
 
     # Set default values for options that are accessed in multiple places: 
     config.setdefault('plugins', {})
@@ -126,8 +134,8 @@ def query_passcode(config):
         try:
             return eval_plugin(plugin, config, subconfig)
 
-        except SkipPlugin as err:
-            display(f"Skipping '{plugin.name}' authentication: {err}")
+        except SkipPlugin as e:
+            display(f"Skipping '{plugin.name}' authentication: {e}")
             continue
 
     raise AllAuthFailed(plugins)
@@ -301,7 +309,7 @@ def run_plugin(plugin, config, subconfigs, *args, **kwargs):
             results.append(result)
 
         except SkipPlugin:
-            display(f"Skipping the '{plugin.stage}.{plugin.name}' plugin: {err}")
+            display(f"Skipping the '{plugin.stage}.{plugin.name}' plugin: {e}")
             continue
 
     return results
@@ -312,8 +320,8 @@ def eval_plugin(plugin, config, subconfig, *args, **kwargs):
     try:
         return plugin(subconfig, *args, **kwargs)
 
-    except PluginError as err:
-        err.plugin = plugin
+    except PluginError as e:
+        e.plugin = plugin
         raise
 
 
@@ -348,7 +356,11 @@ def auth_avendesora(config):
 
     avendesora = PasswordGenerator()
     account = avendesora.get_account(config['account'])
-    return str(account.passcode)
+    fieldname = config.get('field')
+    if fieldname:
+        return str(account.get_value(fieldname))
+    else:
+        return str(account.get_passcode())
 
 def archive_ssh(config, archive):
     """
@@ -382,7 +394,7 @@ def archive_emborg(config, archive):
     copy_to_archive('~/.config/emborg', archive)
 
     with set_output_prefs(prog_name='emborg'):
-        with Emborg() as emborg:
+        with Emborg(name=config.get('config')) as emborg:
             emborg.run_borg(
                 cmd = 'key export',
                 args = [emborg.destination(), archive / '.config/borg.repokey']
@@ -408,8 +420,8 @@ def publish_scp(config, workspace):
         try:
             run(['ssh', host, f'mkdir -p {remote_dir}'], run_flags)
             run(['scp', '-r', workspace, f'{host}:{remote_dir}'], run_flags)
-        except Error as err:
-            err.reraise(codicil=err.cmd)
+        except Error as e:
+            e.reraise(codicil=e.cmd)
         display(f"Archive copied to '{host}'.")
 
 def publish_mount(config, workspace):

--- a/sparekeys/main.py
+++ b/sparekeys/main.py
@@ -383,11 +383,10 @@ def archive_emborg(config, archive):
 
     with set_output_prefs(prog_name='emborg'):
         with Emborg() as emborg:
-            cmd = 'borg key export'.split() + [
-                    emborg.repository,
-                    archive / '.config/borg.repokey',
-            ]
-            emborg.run_borg(cmd)
+            emborg.run_borg(
+                cmd = 'key export',
+                args = [emborg.destination(), archive / '.config/borg.repokey']
+            )
 
 def archive_avendesora(config, archive):
     """

--- a/sparekeys/main.py
+++ b/sparekeys/main.py
@@ -376,19 +376,18 @@ def archive_emborg(config, archive):
     """
     Copy `~/.config/borg` and `~/.config/emborg` into the archive.
     """
-    from emborg.command import run_borg
-    from emborg.settings import Settings
+    from emborg import Emborg
 
     copy_to_archive('~/.config/borg', archive)
     copy_to_archive('~/.config/emborg', archive)
 
     with set_output_prefs(prog_name='emborg'):
-        with Settings() as settings:
+        with Emborg() as emborg:
             cmd = 'borg key export'.split() + [
-                    settings.repository,
+                    emborg.repository,
                     archive / '.config/borg.repokey',
             ]
-            run_borg(cmd, settings)
+            emborg.run_borg(cmd)
 
 def archive_avendesora(config, archive):
     """

--- a/sparekeys/main.py
+++ b/sparekeys/main.py
@@ -24,7 +24,7 @@ Options:
         Eliminate any unnecessary output (implies --yes).
 """
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 __author__ = "Ken & Kale Kundert"
 __slug__ = 'sparekeys'
 


### PR DESCRIPTION
Kale I have create two new config file options:
[auth.avendesora] field
    this allows someone to specify the field in an account that holds the passcode.
[emborg] config
    this allows someone to specify their emborg config if they want to use something other than the default, which is needed if they use a composite config for the default.